### PR TITLE
make cluster name configurable

### DIFF
--- a/modules/emr/README.md
+++ b/modules/emr/README.md
@@ -42,3 +42,10 @@ Type: `map`
 
 Default: `<map>`
 
+### cluster\_name
+
+Description: Name of the EMR cluster that is created.
+
+Type: `string`
+
+Default: `"segment-data-lake"`

--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -1,7 +1,7 @@
 # Creates an EMR cluster that will be used to transform and load events into the Data Lake.
 # https://www.terraform.io/docs/providers/aws/r/emr_cluster.html
 resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
-  name          = "segment-data-lake"
+  name          = "${var.cluster_name}"
   release_label = "emr-5.27.0"
   applications  = ["Hadoop", "Hive", "Spark"]
 
@@ -123,7 +123,7 @@ EOF
 
 # IAM role for EMR Service
 resource "aws_iam_role" "iam_emr_service_role" {
-  name = "iam_emr_service_role"
+  name = "${var.cluster_name}-iam_emr_service_role"
 
   assume_role_policy = <<EOF
 {
@@ -143,7 +143,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "iam_emr_service_policy" {
-  name = "iam_emr_service_policy"
+  name = "${var.cluster_name}-iam_emr_service_policy"
   role = "${aws_iam_role.iam_emr_service_role.id}"
 
   policy = <<EOF
@@ -214,7 +214,7 @@ EOF
 
 # IAM Role for EC2 Instance Profile
 resource "aws_iam_role" "iam_emr_profile_role" {
-  name = "iam_emr_profile_role"
+  name = "${var.cluster_name}-iam_emr_profile_role"
 
   assume_role_policy = <<EOF
 {
@@ -234,12 +234,12 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "emr_profile" {
-  name  = "emr_profile"
+  name  = "${var.cluster_name}-emr_profile"
   roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
 }
 
 resource "aws_iam_role_policy" "iam_emr_profile_policy" {
-  name = "iam_emr_profile_policy"
+  name = "${var.cluster_name}-iam_emr_profile_policy"
   role = "${aws_iam_role.iam_emr_profile_role.id}"
 
   policy = <<EOF

--- a/modules/emr/variables.tf
+++ b/modules/emr/variables.tf
@@ -26,6 +26,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "cluster_name" {
+  description = "Name of the EMR cluster that the module creates"
+  type        = "string"
+  default     = "segment-data-lake"
+}
+
 locals {
   tags = "${merge(map("vendor", "segment"), var.tags)}"
 }

--- a/test/test_fixture/main.tf
+++ b/test/test_fixture/main.tf
@@ -31,4 +31,5 @@ module "emr" {
   s3_bucket = "data_lake_tf_test_s3_bucket"
   subnet_id = "subnet-00f137e4f3a6f8356"
   tags      = "${local.tags}"
+  cluster_name = "test-cluster"
 }


### PR DESCRIPTION
The tf module fails when to create IAM roles for the EMR cluster since the names for the roles are fixed. If the role has already been created before, then the EMR module fails to start the cluster. This PR adds a way to configure the cluster name which will be prefixed to the role names so that each cluster can get its own IAM roles. This will ensure we can create more than 1 cluster using this module.
Error encountered before this change:
```       Error: Error creating IAM Role iam_emr_service_role: EntityAlreadyExists: Role with name iam_emr_service_role already exists.
        status code: 409, request id: 66d39eb7-04ff-40e4-bd6e-2d741a5c4b7d
         on ../../modules/emr/main.tf line 125, in resource "aws_iam_role" "iam_emr_service_role":
        125: resource "aws_iam_role" "iam_emr_service_role" {
```