### PR TITLE
feat(glue): add database_name output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 	# frozen_string_literal: true
 
-ruby '2.4.2'
+ruby '>=2.4.2'
 
 source 'https://rubygems.org/' do
   gem 'aws-sdk', '~> 3.0.1'

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ fmt:
 	terraform fmt -recursive
 
 lint:
-	tflint ./modules/glue
-	tflint ./modules/iam
-	tflint ./modules/emr
+	tflint --disable-rule=terraform_deprecated_interpolation ./modules/glue
+	tflint --disable-rule=terraform_deprecated_interpolation ./modules/iam
+	tflint --disable-rule=terraform_deprecated_interpolation ./modules/emr
 
 docs:
 	terraform-docs markdown document ./modules/glue > ./modules/glue/README.md

--- a/modules/emr/README.md
+++ b/modules/emr/README.md
@@ -1,3 +1,9 @@
+## Providers
+
+The following providers are used by this module:
+
+- aws
+
 ## Required Inputs
 
 The following input variables are required:
@@ -17,6 +23,14 @@ Type: `string`
 ## Optional Inputs
 
 The following input variables are optional (have default values):
+
+### cluster\_name
+
+Description: Name of the EMR cluster that the module creates
+
+Type: `string`
+
+Default: `"segment-data-lake"`
 
 ### master\_security\_group
 
@@ -40,12 +54,9 @@ Description: A map of tags to add to all resources. A vendor=segment tag will be
 
 Type: `map`
 
-Default: `<map>`
+Default: `{}`
 
-### cluster\_name
+## Outputs
 
-Description: Name of the EMR cluster that is created.
+No output.
 
-Type: `string`
-
-Default: `"segment-data-lake"`

--- a/modules/glue/README.md
+++ b/modules/glue/README.md
@@ -1,3 +1,9 @@
+## Providers
+
+The following providers are used by this module:
+
+- aws
+
 ## Required Inputs
 
 The following input variables are required:
@@ -19,4 +25,12 @@ Description: Description of the database.
 Type: `string`
 
 Default: `"Segment Data Lake"`
+
+## Outputs
+
+The following outputs are exported:
+
+### database\_name
+
+Description: n/a
 

--- a/modules/glue/output.tf
+++ b/modules/glue/output.tf
@@ -1,0 +1,3 @@
+output "database_name" {
+  value = "${aws_glue_catalog_database.segment_data_lake_glue_catalog.name}"
+}

--- a/modules/glue/variables.tf
+++ b/modules/glue/variables.tf
@@ -3,7 +3,6 @@ variable "name" {
   type        = "string"
 }
 
-
 variable "description" {
   description = "Description of the database."
   type        = "string"

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -1,3 +1,9 @@
+## Providers
+
+The following providers are used by this module:
+
+- aws
+
 ## Required Inputs
 
 The following input variables are required:
@@ -34,13 +40,20 @@ Type: `string`
 
 Default: `"segment-data-lake-role"`
 
-### segment\_aws\_account
+### segment\_aws\_accounts
 
-Description: ARN of the AWS account used by Segment to connect to your Data Lake.
+Description: ARN of the AWS accounts used by Segment to connect to your Data Lake.
 
-Type: `string`
+Type: `list`
 
-Default: `"arn:aws:iam::798609480926:root"`
+Default:
+
+```json
+[
+  "arn:aws:iam::798609480926:root",
+  "arn:aws:iam::294048959147:root"
+]
+```
 
 ### tags
 
@@ -48,5 +61,9 @@ Description: A map of tags to add to all resources. A vendor=segment tag will be
 
 Type: `map`
 
-Default: `<map>`
+Default: `{}`
+
+## Outputs
+
+No output.
 

--- a/test/test_fixture/main.tf
+++ b/test/test_fixture/main.tf
@@ -28,8 +28,8 @@ module "iam" {
 module "emr" {
   source = "../../modules/emr"
 
-  s3_bucket = "data_lake_tf_test_s3_bucket"
-  subnet_id = "subnet-00f137e4f3a6f8356"
-  tags      = "${local.tags}"
+  s3_bucket    = "data_lake_tf_test_s3_bucket"
+  subnet_id    = "subnet-00f137e4f3a6f8356"
+  tags         = "${local.tags}"
   cluster_name = "test-cluster"
 }


### PR DESCRIPTION
We don't export any values from any of our modules, so I figured I would start with something small to break the ice.

In our docs we require basically all the config to go into local variables, but we could avoid some boilerplate and allow our customers to use modules/resources to define things like their S3 buckets and still allow for a proper dependency tree so their TF will create things in the right order (if everything is a local var, it could create things out of order and error on that first attempt). Beyond this, it reduces duplication in the config.

Atm, this is the only missing output that allows me to eliminate `local` vars entirely from my data lake config.