### PR TITLE
update access to glue

### DIFF
--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -78,6 +78,7 @@ data "aws_iam_policy_document" "segment_data_lake_policy_document" {
   statement {
     actions = [
       "glue:CreateTable",
+      "glue:CreateDatabase",
       "glue:GetTable",
       "glue:GetTables",
       "glue:UpdateTable",
@@ -100,8 +101,8 @@ data "aws_iam_policy_document" "segment_data_lake_policy_document" {
     resources = [
       "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog",
       "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/default",
-      "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/${var.glue_database_name}",
-      "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.glue_database_name}/*",
+      "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/*",
+      "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/*",
     ]
 
     effect = "Allow"

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -20,12 +20,6 @@ variable "s3_bucket" {
   type        = "string"
 }
 
-variable "glue_database_name" {
-  description = "Name of the Glue database used by the Data Lake."
-  type        = "string"
-  default     = "segment"
-}
-
 variable "tags" {
   description = "A map of tags to add to all resources. A vendor=segment tag will be added automatically."
   type        = "map"


### PR DESCRIPTION
Since we are allowing customers to create a separate DB per source now, updating the IAM policy for each source they want to add might get cumbersome. This change will give us more access but that is probably fine since its limited to operations in this single catalog. The Data Lakes service now also attempts to create the DB if it does not exist so the customers dont event need to create a DB anymore.

