### PR TITLE
feat(emr): add config for log s3 prefix

### DIFF
--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -5,7 +5,7 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
   release_label = "emr-5.27.0"
   applications  = ["Hadoop", "Hive", "Spark"]
 
-  log_uri = "s3://${var.s3_bucket}/logs"
+  log_uri = "s3://${var.s3_bucket}/${var.emr_logs_s3_prefix}"
 
   ec2_attributes {
     subnet_id                         = "${var.subnet_id}"

--- a/modules/emr/variables.tf
+++ b/modules/emr/variables.tf
@@ -35,7 +35,7 @@ variable "cluster_name" {
 variable "emr_logs_s3_prefix" {
   description = "Prefix for writing EMR cluster logs to S3"
   type        = "string"
-  default     = "logs"
+  default     = "logs/"
 }
 
 locals {

--- a/modules/emr/variables.tf
+++ b/modules/emr/variables.tf
@@ -32,6 +32,12 @@ variable "cluster_name" {
   default     = "segment-data-lake"
 }
 
+variable "emr_logs_s3_prefix" {
+  description = "Prefix for writing EMR cluster logs to S3"
+  type        = "string"
+  default     = "logs"
+}
+
 locals {
   tags = "${merge(map("vendor", "segment"), var.tags)}"
 }


### PR DESCRIPTION
I found the `logs/` prefix for EMR logs to be a bit vague, so I wanted to override it with my own config. This config allows for this, while retaining backwards-compatibility with the existing functionality.