### PR TITLE
docs(readme): general cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ resource "aws_s3_bucket" "segment_datalake_s3" {
 # This is optional.
 # Segment will create a DB for you if it does not exist already.
 module "glue" {
-  source = "git@github.com:segmentio/terraform-aws-data-lake//modules/glue?ref=v0.1.1"
+  source = "git@github.com:segmentio/terraform-aws-data-lake//modules/glue?ref=v0.1.5"
 
   name = "segment_data_lake"
 }
@@ -64,7 +64,7 @@ module "iam" {
 }
 
 module "emr" {
-  source = "git@github.com:segmentio/terraform-aws-data-lake//modules/emr?ref=v0.1.1"
+  source = "git@github.com:segmentio/terraform-aws-data-lake//modules/emr?ref=v0.1.5"
 
   s3_bucket = "${aws_s3_bucket.segment_datalake_s3.name}"
   subnet_id = "subnet-XXX" # Replace this with the subnet ID you want the EMR cluster to run in.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ module "glue" {
   name = "segment_data_lake"
 }
 
-# Creates the IAM policy that allows Segment to access the necessary resources
+# Creates the IAM Policy that allows Segment to access the necessary resources
 # in your AWS account for loading your data.
 module "iam" {
   source = "git@github.com:segmentio/terraform-aws-data-lake//modules/iam?ref=v0.1.4"
@@ -66,6 +66,8 @@ module "iam" {
   external_ids = "${values(local.segment_sources)}"
 }
 
+# Creates an EMR Cluster that Segment uses for performing the final ETL on your
+# data that lands in S3.
 module "emr" {
   source = "git@github.com:segmentio/terraform-aws-data-lake//modules/emr?ref=v0.1.5"
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ provider "aws" {
 
 locals {
   segment_sources = {
-    my_website = "<Segment Source ID>"  # Find this in the Segment UI: Settings > API Keys > Source ID
+    # Find these in the Segment UI: (for each source you intend to connect)
+    #  - Settings > SQL Settings > Schema Name (aka: Source Slug)
+    #  - Settings > API Keys > Source ID
+    <Segment Source Slug> = "<Segment Source ID>"
   }
 }
 
@@ -77,7 +80,7 @@ Note that creating the EMR cluster can take a while (typically 5 minutes).
 
 Once applied, make a note of the following (you'll need to provide this information to your Segment contact):
 * The **AWS Region** and **AWS Account ID** where your Data Lake was configured
-* The **Source ID** for _each_ Segment source that will be connected to the data lake
+* The **Source ID and Slug** for _each_ Segment source that will be connected to the data lake
 * The generated **EMR Cluster ID**
 * The generated **IAM Role ARN**
 

--- a/modules/emr/variables.tf
+++ b/modules/emr/variables.tf
@@ -33,7 +33,7 @@ variable "cluster_name" {
 }
 
 variable "emr_logs_s3_prefix" {
-  description = "Prefix for writing EMR cluster logs to S3"
+  description = "Prefix for writing EMR cluster logs to S3. Make sure to include a trailing slash (/) when setting this."
   type        = "string"
   default     = "logs/"
 }


### PR DESCRIPTION
This PR aims to improve the README by fixing some syntax errors and providing a cleaner base to copy-paste for new customers:

 - Remove the extra `tags` layer under `locals` (syntax error)
 - Using a terraform map for source slug -> source id that is referenced in config (reduced copy-paste)
 - Treating the `glue` module as deprecated so making it a bit less prominent in general
 - Update the docs for `module.emr.emr_logs_s3_prefix` to emphasize the trailing slash in the case of customization