### PR TITLE
feat(emr): add output for cluster id

### DIFF
--- a/modules/emr/output.tf
+++ b/modules/emr/output.tf
@@ -1,0 +1,3 @@
+output "cluster_id" {
+  value = "${aws_emr_cluster.segment_data_lake_emr_cluster.id}"
+}


### PR DESCRIPTION
This PR adds a `cluster_id` output to the `emr` module which should expose the created cluster ID to other terraform resources.