### PR TITLE
add permissions to create cluster, fix autoscaling

### DIFF
--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -19,7 +19,7 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
 
   master_instance_group {
     instance_type = "m5.xlarge"
-    name = "master_group"
+    name          = "master_group"
 
     ebs_config {
       size                 = "64"
@@ -31,7 +31,7 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
   core_instance_group {
     instance_type  = "m5.xlarge"
     instance_count = 2
-    name = "core_group"
+    name           = "core_group"
 
 
     ebs_config {

--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -11,14 +11,15 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
     subnet_id                         = "${var.subnet_id}"
     emr_managed_master_security_group = "${var.master_security_group}"
     emr_managed_slave_security_group  = "${var.slave_security_group}"
-    instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
+    instance_profile                  = "${var.iam_emr_instance_profile}"
   }
 
-  service_role     = "${aws_iam_role.iam_emr_service_role.arn}"
-  autoscaling_role = "${aws_iam_role.iam_emr_service_role.arn}"
+  service_role     = "${var.iam_emr_service_role}"
+  autoscaling_role = "${var.iam_emr_autoscaling_role}"
 
   master_instance_group {
     instance_type = "m5.xlarge"
+    name = "master_group"
 
     ebs_config {
       size                 = "64"
@@ -30,6 +31,8 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
   core_instance_group {
     instance_type  = "m5.xlarge"
     instance_count = 2
+    name = "core_group"
+
 
     ebs_config {
       size                 = "64"
@@ -39,61 +42,59 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
 
     autoscaling_policy = <<EOF
 {
-"Constraints": {
-  "MinCapacity": 1,
-  "MaxCapacity": 4
-},
-"Rules": [
-  {
-    "Name": "ScaleOutMemoryPercentage",
-    "Description": "Scale out if YARNMemoryAvailablePercentage is less than 15",
-    "Action": {
-      "SimpleScalingPolicyConfiguration": {
-        "AdjustmentType": "CHANGE_IN_CAPACITY",
-        "ScalingAdjustment": 1,
-        "CoolDown": 300
-      }
-    },
-    "Trigger": {
-      "CloudWatchAlarmDefinition": {
-        "ComparisonOperator": "LESS_THAN",
-        "EvaluationPeriods": 1,
-        "MetricName": "YARNMemoryAvailablePercentage",
-        "Namespace": "AWS/ElasticMapReduce",
-        "Period": 300,
-        "Statistic": "AVERAGE",
-        "Threshold": 15.0,
-        "Unit": "PERCENT"
-      }
-    }
-  },
-  {
-    "Name": "ScaleInMemoryPercentage",
-    "Description": "Scale in if YARNMemoryAvailablePercentage is greater than 75",
-    "Action": {
-      "SimpleScalingPolicyConfiguration": {
-        "AdjustmentType": "CHANGE_IN_CAPACITY",
-        "ScalingAdjustment": -1,
-        "CoolDown": 300
-      }
-    },
-    "Trigger": {
-      "CloudWatchAlarmDefinition": {
-        "ComparisonOperator": "GREATER_THAN",
-        "EvaluationPeriods": 1,
-        "MetricName": "YARNMemoryAvailablePercentage",
-        "Namespace": "AWS/ElasticMapReduce",
-        "Period": 300,
-        "Statistic": "AVERAGE",
-        "Threshold": 75.0,
-        "Unit": "PERCENT"
-      }
-    }
-  }
-]
+	"Constraints": {
+		"MinCapacity": 1,
+		"MaxCapacity": 4
+	},
+	"Rules": [{
+		"Action": {
+			"SimpleScalingPolicyConfiguration": {
+				"ScalingAdjustment": 1,
+				"CoolDown": 300,
+				"AdjustmentType": "CHANGE_IN_CAPACITY"
+			}
+		},
+		"Description": "",
+		"Trigger": {
+			"CloudWatchAlarmDefinition": {
+				"MetricName": "HDFSUtilization",
+				"ComparisonOperator": "GREATER_THAN_OR_EQUAL",
+				"Statistic": "AVERAGE",
+				"Period": 300,
+				"EvaluationPeriods": 1,
+				"Unit": "PERCENT",
+				"Namespace": "AWS/ElasticMapReduce",
+				"Threshold": 80
+			}
+		},
+		"Name": "ScaleOutHDFSUtilization"
+	}, {
+		"Action": {
+			"SimpleScalingPolicyConfiguration": {
+				"ScalingAdjustment": -1,
+				"CoolDown": 300,
+				"AdjustmentType": "CHANGE_IN_CAPACITY"
+			}
+		},
+		"Description": "",
+		"Trigger": {
+			"CloudWatchAlarmDefinition": {
+				"MetricName": "HDFSUtilization",
+				"ComparisonOperator": "LESS_THAN",
+				"Statistic": "AVERAGE",
+				"Period": 300,
+				"EvaluationPeriods": 1,
+				"Unit": "PERCENT",
+				"Namespace": "AWS/ElasticMapReduce",
+				"Threshold": 50
+			}
+		},
+		"Name": "ScaleInMemoryPercentage"
+	}]
 }
 EOF
   }
+
 
   configurations_json = <<EOF
   [
@@ -115,165 +116,114 @@ EOF
   tags = "${local.tags}"
 }
 
-###
+resource "aws_emr_instance_group" "task" {
+  name       = "task_group"
+  cluster_id = join("", aws_emr_cluster.segment_data_lake_emr_cluster.*.id)
 
-# IAM Role setups
+  instance_type  = "m5.xlarge"
+  instance_count = "2"
 
-###
+  ebs_config {
+    size                 = "64"
+    type                 = "gp2"
+    volumes_per_instance = 1
+  }
 
-# IAM role for EMR Service
-resource "aws_iam_role" "iam_emr_service_role" {
-  name = "${var.cluster_name}-iam_emr_service_role"
-
-  assume_role_policy = <<EOF
+  autoscaling_policy = <<EOF
 {
-  "Version": "2008-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "elasticmapreduce.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "iam_emr_service_policy" {
-  name = "${var.cluster_name}-iam_emr_service_policy"
-  role = "${aws_iam_role.iam_emr_service_role.id}"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [{
-        "Effect": "Allow",
-        "Resource": "*",
-        "Action": [
-            "ec2:AuthorizeSecurityGroupEgress",
-            "ec2:AuthorizeSecurityGroupIngress",
-            "ec2:CancelSpotInstanceRequests",
-            "ec2:CreateNetworkInterface",
-            "ec2:CreateSecurityGroup",
-            "ec2:CreateTags",
-            "ec2:DeleteNetworkInterface",
-            "ec2:DeleteSecurityGroup",
-            "ec2:DeleteTags",
-            "ec2:DescribeAvailabilityZones",
-            "ec2:DescribeAccountAttributes",
-            "ec2:DescribeDhcpOptions",
-            "ec2:DescribeInstanceStatus",
-            "ec2:DescribeInstances",
-            "ec2:DescribeKeyPairs",
-            "ec2:DescribeNetworkAcls",
-            "ec2:DescribeNetworkInterfaces",
-            "ec2:DescribePrefixLists",
-            "ec2:DescribeRouteTables",
-            "ec2:DescribeSecurityGroups",
-            "ec2:DescribeSpotInstanceRequests",
-            "ec2:DescribeSpotPriceHistory",
-            "ec2:DescribeSubnets",
-            "ec2:DescribeVpcAttribute",
-            "ec2:DescribeVpcEndpoints",
-            "ec2:DescribeVpcEndpointServices",
-            "ec2:DescribeVpcs",
-            "ec2:DetachNetworkInterface",
-            "ec2:ModifyImageAttribute",
-            "ec2:ModifyInstanceAttribute",
-            "ec2:RequestSpotInstances",
-            "ec2:RevokeSecurityGroupEgress",
-            "ec2:RunInstances",
-            "ec2:TerminateInstances",
-            "ec2:DeleteVolume",
-            "ec2:DescribeVolumeStatus",
-            "ec2:DescribeVolumes",
-            "ec2:DetachVolume",
-            "iam:GetRole",
-            "iam:GetRolePolicy",
-            "iam:ListInstanceProfiles",
-            "iam:ListRolePolicies",
-            "iam:PassRole",
-            "s3:CreateBucket",
-            "s3:Get*",
-            "s3:List*",
-            "sdb:BatchPutAttributes",
-            "sdb:Select",
-            "sqs:CreateQueue",
-            "sqs:Delete*",
-            "sqs:GetQueue*",
-            "sqs:PurgeQueue",
-            "sqs:ReceiveMessage"
-        ]
-    }]
-}
-EOF
-}
-
-# IAM Role for EC2 Instance Profile
-resource "aws_iam_role" "iam_emr_profile_role" {
-  name = "${var.cluster_name}-iam_emr_profile_role"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2008-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_instance_profile" "emr_profile" {
-  name  = "${var.cluster_name}-emr_profile"
-  roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
-}
-
-resource "aws_iam_role_policy" "iam_emr_profile_policy" {
-  name = "${var.cluster_name}-iam_emr_profile_policy"
-  role = "${aws_iam_role.iam_emr_profile_role.id}"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [{
-        "Effect": "Allow",
-        "Resource": "*",
-        "Action": [
-            "cloudwatch:*",
-            "dynamodb:*",
-            "ec2:Describe*",
-            "elasticmapreduce:Describe*",
-            "elasticmapreduce:ListBootstrapActions",
-            "elasticmapreduce:ListClusters",
-            "elasticmapreduce:ListInstanceGroups",
-            "elasticmapreduce:ListInstances",
-            "elasticmapreduce:ListSteps",
-            "kinesis:CreateStream",
-            "kinesis:DeleteStream",
-            "kinesis:DescribeStream",
-            "kinesis:GetRecords",
-            "kinesis:GetShardIterator",
-            "kinesis:MergeShards",
-            "kinesis:PutRecord",
-            "kinesis:SplitShard",
-            "rds:Describe*",
-            "s3:*",
-            "sdb:*",
-            "sns:*",
-            "sqs:*",
-            "glue:*"
-        ]
-    }]
-}
+"Constraints": {
+			"MinCapacity": 1,
+			"MaxCapacity": 4
+		},
+		"Rules": [{
+			"Action": {
+				"SimpleScalingPolicyConfiguration": {
+					"ScalingAdjustment": 1,
+					"CoolDown": 120,
+					"AdjustmentType": "CHANGE_IN_CAPACITY"
+				}
+			},
+			"Description": "",
+			"Trigger": {
+				"CloudWatchAlarmDefinition": {
+					"MetricName": "ContainerPendingRatio",
+					"ComparisonOperator": "GREATER_THAN_OR_EQUAL",
+					"Statistic": "AVERAGE",
+					"Period": 300,
+					"EvaluationPeriods": 1,
+					"Unit": "COUNT",
+					"Namespace": "AWS/ElasticMapReduce",
+					"Threshold": 0.75
+				}
+			},
+			"Name": "ScaleOutContainersPending"
+		}, {
+			"Action": {
+				"SimpleScalingPolicyConfiguration": {
+					"ScalingAdjustment": 1,
+					"CoolDown": 120,
+					"AdjustmentType": "CHANGE_IN_CAPACITY"
+				}
+			},
+			"Description": "",
+			"Trigger": {
+				"CloudWatchAlarmDefinition": {
+					"MetricName": "YARNMemoryAvailablePercentage",
+					"ComparisonOperator": "LESS_THAN_OR_EQUAL",
+					"Statistic": "AVERAGE",
+					"Period": 300,
+					"EvaluationPeriods": 1,
+					"Unit": "PERCENT",
+					"Namespace": "AWS/ElasticMapReduce",
+					"Threshold": 15
+				}
+			},
+			"Name": "ScaleOutYarnMemoryUtilization"
+		}, {
+			"Action": {
+				"SimpleScalingPolicyConfiguration": {
+					"ScalingAdjustment": -1,
+					"CoolDown": 120,
+					"AdjustmentType": "CHANGE_IN_CAPACITY"
+				}
+			},
+			"Description": "",
+			"Trigger": {
+				"CloudWatchAlarmDefinition": {
+					"MetricName": "ContainerPendingRatio",
+					"ComparisonOperator": "GREATER_THAN_OR_EQUAL",
+					"Statistic": "AVERAGE",
+					"Period": 300,
+					"EvaluationPeriods": 1,
+					"Unit": "COUNT",
+					"Namespace": "AWS/ElasticMapReduce",
+					"Threshold": 0
+				}
+			},
+			"Name": "ScaleInContainersPending"
+		}, {
+			"Action": {
+				"SimpleScalingPolicyConfiguration": {
+					"ScalingAdjustment": -1,
+					"CoolDown": 120,
+					"AdjustmentType": "CHANGE_IN_CAPACITY"
+				}
+			},
+			"Description": "",
+			"Trigger": {
+				"CloudWatchAlarmDefinition": {
+					"MetricName": "YARNMemoryAvailablePercentage",
+					"ComparisonOperator": "GREATER_THAN_OR_EQUAL",
+					"Statistic": "AVERAGE",
+					"Period": 300,
+					"EvaluationPeriods": 1,
+					"Unit": "PERCENT",
+					"Namespace": "AWS/ElasticMapReduce",
+					"Threshold": 75
+				}
+			},
+			"Name": "ScaleInYarnMemoryUtilization"
+		}]
+	}
 EOF
 }

--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -43,7 +43,7 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
     autoscaling_policy = <<EOF
 {
 	"Constraints": {
-		"MinCapacity": 1,
+		"MinCapacity": 2,
 		"MaxCapacity": 4
 	},
 	"Rules": [{
@@ -132,7 +132,7 @@ resource "aws_emr_instance_group" "task" {
   autoscaling_policy = <<EOF
 {
 "Constraints": {
-			"MinCapacity": 1,
+			"MinCapacity": 2,
 			"MaxCapacity": 4
 		},
 		"Rules": [{

--- a/modules/emr/variables.tf
+++ b/modules/emr/variables.tf
@@ -38,6 +38,18 @@ variable "emr_logs_s3_prefix" {
   default     = "logs/"
 }
 
+variable "iam_emr_service_role" {
+  type = "string"
+}
+
+variable "iam_emr_autoscaling_role" {
+  type = "string"
+}
+
+variable "iam_emr_instance_profile" {
+  type = "string"
+}
+
 locals {
   tags = "${merge(map("vendor", "segment"), var.tags)}"
 }

--- a/modules/emr/variables.tf
+++ b/modules/emr/variables.tf
@@ -39,15 +39,18 @@ variable "emr_logs_s3_prefix" {
 }
 
 variable "iam_emr_service_role" {
-  type = "string"
+  description = "Name of the EMR service role"
+  type        = "string"
 }
 
 variable "iam_emr_autoscaling_role" {
-  type = "string"
+  description = "Name of the EMR autoscaling role"
+  type        = "string"
 }
 
 variable "iam_emr_instance_profile" {
-  type = "string"
+  description = "Name of the EMR EC2 instance profile"
+  type        = "string"
 }
 
 locals {

--- a/modules/iam/output.tf
+++ b/modules/iam/output.tf
@@ -1,0 +1,11 @@
+output "iam_emr_instance_profile" {
+  value = "${aws_iam_instance_profile.segment_emr_instance_profile.name}"
+}
+
+output "iam_emr_service_role" {
+  value = "${aws_iam_role.segment_emr_service_role.name}"
+}
+
+output "iam_emr_autoscaling_role" {
+  value = "${aws_iam_role.segment_emr_autoscaling_role.name}"
+}

--- a/test/test_fixture/main.tf
+++ b/test/test_fixture/main.tf
@@ -34,6 +34,6 @@ module "emr" {
 
   # LEAVE THIS AS-IS
   iam_emr_autoscaling_role = "${module.iam.iam_emr_autoscaling_role}"
-  iam_emr_service_role = "${module.iam.iam_emr_service_role}"
+  iam_emr_service_role     = "${module.iam.iam_emr_service_role}"
   iam_emr_instance_profile = "${module.iam.iam_emr_instance_profile}"
 }

--- a/test/test_fixture/main.tf
+++ b/test/test_fixture/main.tf
@@ -31,4 +31,9 @@ module "emr" {
   subnet_id    = "subnet-00f137e4f3a6f8356"
   tags         = "${local.tags}"
   cluster_name = "test-cluster"
+
+  # LEAVE THIS AS-IS
+  iam_emr_autoscaling_role = "${module.iam.iam_emr_autoscaling_role}"
+  iam_emr_service_role = "${module.iam.iam_emr_service_role}"
+  iam_emr_instance_profile = "${module.iam.iam_emr_instance_profile}"
 }


### PR DESCRIPTION
This PR makes the following changes:
* Gives the Segment role permissions to create EMR clusters
* Updates the EMR service role to only have the permissions that a job running on the cluster requires.
* Updates the EMR service role to have permissions to attach autoscaling groups. There were previously failing to attach due to insufficient permissions.
* All roles are now created in the IAM module and exported using output vars. The EMR module is passed these outputs from the IAM module. This will make it easy to completely get rid of the EMR module when we decide to fully manage EMR clusters.
* Add a task instance group to the EMR module.
Autoscaling rules are set per the guidelines here: https://aws.amazon.com/blogs/big-data/best-practices-for-resizing-and-automatic-scaling-in-amazon-emr/