### PR TITLE
Parameterizing EC2 Instance Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ If all else fails, teardown and start over.
 
 Terraform 0.11 or higher is supported.
 
+NOTE: Release v0.2.0 onwards only Terraform 0.12 or higher is supported.
+
 # Development
 
 To develop in this repository, you'll want the following tools set up:

--- a/modules/emr/README.md
+++ b/modules/emr/README.md
@@ -48,6 +48,30 @@ Type: `string`
 
 Default: `""`
 
+### master_instance_type
+
+Description: EC2 Instance Type for Master
+
+Type: `string`
+
+Default: `"m5.xlarge"`
+
+### core_instance_type
+
+Description: EC2 Instance Type for Core Nodes
+
+Type: `string`
+
+Default: `"m5.xlarge"`
+
+# task_instance_type
+
+Description: EC2 Instance Type for Task Nodes
+
+Type: `string`
+
+Default: `"m5.xlarge"`
+
 ### tags
 
 Description: A map of tags to add to all resources. A vendor=segment tag will be added automatically (which is also used by the IAM policy to provide Segment access to submit jobs).

--- a/modules/emr/README.md
+++ b/modules/emr/README.md
@@ -48,7 +48,7 @@ Type: `string`
 
 Default: `""`
 
-### master_instance_type
+### master\_instance\_type
 
 Description: EC2 Instance Type for Master
 
@@ -56,7 +56,7 @@ Type: `string`
 
 Default: `"m5.xlarge"`
 
-### core_instance_type
+### core\_instance\_type
 
 Description: EC2 Instance Type for Core Nodes
 
@@ -64,13 +64,45 @@ Type: `string`
 
 Default: `"m5.xlarge"`
 
-# task_instance_type
+# task\_instance\_type
 
 Description: EC2 Instance Type for Task Nodes
 
 Type: `string`
 
 Default: `"m5.xlarge"`
+
+# core\_instance\_count
+
+Description: Number of instances of Core Nodes
+
+Type: `string`
+
+Default: `"2"`
+
+# core\_instance\_max\_count
+
+Description: Max number of Core Nodes used on autoscale
+
+Type: `string`
+
+Default: `"4"`
+
+# task\_instance\_count
+
+Description: Number of instances of Task Nodes
+
+Type: `string`
+
+Default: `"2"`
+
+# task\_instance\_max\_count
+
+Description: Max number of Task Nodes used on autoscale
+
+Type: `string`
+
+Default: `"4"`
 
 ### tags
 

--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -30,7 +30,7 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
 
   core_instance_group {
     instance_type  = "${var.core_instance_type}"
-    instance_count = 2
+    instance_count = "${var.core_instance_count}"
     name           = "core_group"
 
 
@@ -43,8 +43,8 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
     autoscaling_policy = <<EOF
 {
 	"Constraints": {
-		"MinCapacity": 2,
-		"MaxCapacity": 4
+		"MinCapacity": tonumber(${var.core_instance_count}),
+		"MaxCapacity": tonumber(${var.core_instance_max_count})
 	},
 	"Rules": [{
 		"Action": {
@@ -121,7 +121,7 @@ resource "aws_emr_instance_group" "task" {
   cluster_id = join("", aws_emr_cluster.segment_data_lake_emr_cluster.*.id)
 
   instance_type  = "${var.task_instance_type}"
-  instance_count = "2"
+  instance_count = "${var.task_instance_count}"
 
   ebs_config {
     size                 = "64"
@@ -132,8 +132,8 @@ resource "aws_emr_instance_group" "task" {
   autoscaling_policy = <<EOF
 {
 "Constraints": {
-			"MinCapacity": 2,
-			"MaxCapacity": 4
+			"MinCapacity": tonumber(${var.task_instance_count}),
+			"MaxCapacity": tonumber(${var.task_instance_max_count})
 		},
 		"Rules": [{
 			"Action": {

--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -18,7 +18,7 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
   autoscaling_role = "${var.iam_emr_autoscaling_role}"
 
   master_instance_group {
-    instance_type = "m5.xlarge"
+    instance_type = "${var.master_instance_type}"
     name          = "master_group"
 
     ebs_config {
@@ -29,7 +29,7 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
   }
 
   core_instance_group {
-    instance_type  = "m5.xlarge"
+    instance_type  = "${var.core_instance_type}"
     instance_count = 2
     name           = "core_group"
 
@@ -120,7 +120,7 @@ resource "aws_emr_instance_group" "task" {
   name       = "task_group"
   cluster_id = join("", aws_emr_cluster.segment_data_lake_emr_cluster.*.id)
 
-  instance_type  = "m5.xlarge"
+  instance_type  = "${var.task_instance_type}"
   instance_count = "2"
 
   ebs_config {

--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -43,8 +43,8 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
     autoscaling_policy = <<EOF
 {
 	"Constraints": {
-		"MinCapacity": tonumber(${var.core_instance_count}),
-		"MaxCapacity": tonumber(${var.core_instance_max_count})
+		"MinCapacity": ${var.core_instance_count},
+		"MaxCapacity": ${var.core_instance_max_count}
 	},
 	"Rules": [{
 		"Action": {
@@ -132,8 +132,8 @@ resource "aws_emr_instance_group" "task" {
   autoscaling_policy = <<EOF
 {
 "Constraints": {
-			"MinCapacity": tonumber(${var.task_instance_count}),
-			"MaxCapacity": tonumber(${var.task_instance_max_count})
+			"MinCapacity": ${var.task_instance_count},
+			"MaxCapacity": ${var.task_instance_max_count}
 		},
 		"Rules": [{
 			"Action": {

--- a/modules/emr/variables.tf
+++ b/modules/emr/variables.tf
@@ -71,6 +71,30 @@ variable "task_instance_type" {
   default     = "m5.xlarge"
 }
 
+variable "core_instance_count" {
+  description = "Number of Core Nodes"
+  type        = "string"
+  default     = "2"
+}
+
+variable "core_instance_max_count" {
+  description = "Max number of Core Nodes used on autoscale"
+  type        = "string"
+  default     = "4"
+}
+
+variable "task_instance_count" {
+  description = "Number of instances of Task Nodes"
+  type        = "string"
+  default     = "2"
+}
+
+variable "task_instance_max_count" {
+  description = "Max number of Task Nodes used on autoscale"
+  type        = "string"
+  default     = "4"
+}
+
 locals {
   tags = "${merge(map("vendor", "segment"), var.tags)}"
 }

--- a/modules/emr/variables.tf
+++ b/modules/emr/variables.tf
@@ -53,6 +53,24 @@ variable "iam_emr_instance_profile" {
   type        = "string"
 }
 
+variable "master_instance_type" {
+  description = "EC2 Instance Type for Master"
+  type        = "string"
+  default     = "m5.xlarge"
+}
+
+variable "core_instance_type" {
+  description = "EC2 Instance Type for Core Nodes"
+  type        = "string"
+  default     = "m5.xlarge"
+}
+
+variable "task_instance_type" {
+  description = "EC2 Instance Type for Task Nodes"
+  type        = "string"
+  default     = "m5.xlarge"
+}
+
 locals {
   tags = "${merge(map("vendor", "segment"), var.tags)}"
 }


### PR DESCRIPTION
Parametrizing,
1. Instance Types for Master, Core, and Task Nodes
2. Instance Count for Core and Task Nodes 

- [x] Maintains previous values as defaults
- [x] Allows overrides by EMR module users

Facilitates tuning EMR clusters for optimal cost and performance.