### PR TITLE
fix(emr): get rid of splat

### DIFF
--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -118,7 +118,7 @@ EOF
 
 resource "aws_emr_instance_group" "task" {
   name       = "task_group"
-  cluster_id = join("", aws_emr_cluster.segment_data_lake_emr_cluster.*.id)
+  cluster_id = "${aws_emr_cluster.segment_data_lake_emr_cluster.id}"
 
   instance_type  = "${var.task_instance_type}"
   instance_count = "${var.task_instance_count}"


### PR DESCRIPTION
Within the EMR module, we're using this splat to reference the EMR cluster module, but on a fresh plan/init you'll get an error since this will resolve to an empty value as the EMR cluster has not been created yet.

The splat doesn't seem necessary, so I'm going to a more straightforward interpolation here which at least allows me to init/plan again.