### PR TITLE
feat(iam): restrict production account access to named roles, remove unused account access

### DIFF
--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -7,7 +7,11 @@ variable "suffix" {
 variable "segment_aws_accounts" {
   description = "ARN of the AWS accounts used by Segment to connect to your Data Lake."
   type        = "list"
-  default     = ["arn:aws:iam::798609480926:root", "arn:aws:iam::294048959147:root"]
+  default = [
+    "arn:aws:iam::294048959147:role/datalakes-aws-worker",
+    "arn:aws:iam::294048959147:role/datalakes-customer-service",
+    "arn:aws:iam::294048959147:role/customer-datalakes-prod-admin",
+  ]
 }
 
 variable "external_ids" {


### PR DESCRIPTION
This PR tightens up the security for our IAM Assume Role Policy (in the `iam` module) to only allow access for a few named IAM roles on the Segment side, rather than anything within that AWS account.

This also drops an AWS Account that we no longer use for Data Lakes.