### PR TITLE
More strict IAM permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ override.tf.json
 # End of https://www.gitignore.io/api/osx,ruby,terraform,visualstudiocode
 
 .kitchen/
+
+## IDEA based IDEs
+.idea

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -384,75 +384,82 @@ resource "aws_iam_role_policy" "segment_emr_instance_profile_policy" {
   name = "SegmentEMRInstanceProfilePolicy${var.suffix}"
   role = "${aws_iam_role.segment_emr_instance_profile_role.id}"
 
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [{
-        "Effect": "Allow",
-        "Resource": "*",
-        "Action": [
-            "cloudwatch:*",
-            "ec2:Describe*",
-            "elasticmapreduce:Describe*",
-            "sdb:*"
-        ]
-    },
-    {
-            "Effect": "Allow",
-            "Action": [
-                "s3:AbortMultipartUpload",
-                "s3:CreateBucket",
-                "s3:DeleteObject",
-                "s3:GetBucketVersioning",
-                "s3:GetObject",
-                "s3:GetObjectTagging",
-                "s3:GetObjectVersion",
-                "s3:ListBucket",
-                "s3:ListBucketMultipartUploads",
-                "s3:ListBucketVersions",
-                "s3:ListMultipartUploadParts",
-                "s3:PutBucketVersioning",
-                "s3:PutObject",
-                "s3:PutObjectTagging"
-            ],
-            "Resource": [
-                "arn:aws:s3:::${var.s3_bucket}",
-                "arn:aws:s3:::${var.s3_bucket}/*"
-            ]
-        },
-    {
-            "Effect": "Allow",
-            "Resource": "*",
-            "Action": [
-                "glue:CreateDatabase",
-                "glue:UpdateDatabase",
-                "glue:DeleteDatabase",
-                "glue:GetDatabase",
-                "glue:GetDatabases",
-                "glue:CreateTable",
-                "glue:UpdateTable",
-                "glue:DeleteTable",
-                "glue:GetTable",
-                "glue:GetTables",
-                "glue:GetTableVersions",
-                "glue:CreatePartition",
-                "glue:BatchCreatePartition",
-                "glue:UpdatePartition",
-                "glue:DeletePartition",
-                "glue:BatchDeletePartition",
-                "glue:GetPartition",
-                "glue:GetPartitions",
-                "glue:BatchGetPartition",
-                "glue:CreateUserDefinedFunction",
-                "glue:UpdateUserDefinedFunction",
-                "glue:DeleteUserDefinedFunction",
-                "glue:GetUserDefinedFunction",
-                "glue:GetUserDefinedFunctions"
-            ]
-        }
-]
+  policy = "${data.aws_iam_policy_document.segment_emr_instance_profile_policy_document.json}"
 }
-EOF
+
+data "aws_iam_policy_document" "segment_emr_instance_profile_policy_document" {
+  statement {
+    resources = [
+      "*"
+    ]
+    actions   = [
+      "glue:CreateDatabase",
+      "glue:UpdateDatabase",
+      "glue:DeleteDatabase",
+      "glue:GetDatabase",
+      "glue:GetDatabases",
+      "glue:CreateTable",
+      "glue:UpdateTable",
+      "glue:DeleteTable",
+      "glue:GetTable",
+      "glue:GetTables",
+      "glue:GetTableVersions",
+      "glue:CreatePartition",
+      "glue:BatchCreatePartition",
+      "glue:UpdatePartition",
+      "glue:DeletePartition",
+      "glue:BatchDeletePartition",
+      "glue:GetPartition",
+      "glue:GetPartitions",
+      "glue:BatchGetPartition",
+      "glue:CreateUserDefinedFunction",
+      "glue:UpdateUserDefinedFunction",
+      "glue:DeleteUserDefinedFunction",
+      "glue:GetUserDefinedFunction",
+      "glue:GetUserDefinedFunctions"
+    ]
+    effect    = "Allow"
+
+  }
+
+  statement {
+    resources = [
+      "*"
+    ]
+
+    actions = [
+      "cloudwatch:*",
+      "ec2:Describe*",
+      "elasticmapreduce:Describe*",
+      "sdb:*"
+    ]
+    effect  = "Allow"
+  }
+
+  statement {
+    resources = [
+      "arn:aws:s3:::${var.s3_bucket}",
+      "arn:aws:s3:::${var.s3_bucket}/*"
+    ]
+
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:CreateBucket",
+      "s3:DeleteObject",
+      "s3:GetBucketVersioning",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListBucketVersions",
+      "s3:ListMultipartUploadParts",
+      "s3:PutBucketVersioning",
+      "s3:PutObject",
+      "s3:PutObjectTagging"
+    ]
+    effect  = "Allow"
+  }
 }
 
 # IAM Role for EMR Autoscaling role

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -44,7 +44,6 @@ resource "aws_iam_policy" "segment_data_lake_policy" {
   path        = "/"
   description = "Gives access to resources in your Data Lake"
   policy      = "${data.aws_iam_policy_document.segment_data_lake_policy_document.json}"
-  tags        = "${local.tags}"
 }
 
 data "aws_iam_policy_document" "segment_data_lake_policy_document" {
@@ -216,7 +215,6 @@ resource "aws_iam_policy" "segment_emr_service_role_policy" {
   name   = "SegmentEMRServicePolicy${var.suffix}"
   path   = "/"
   policy = "${data.aws_iam_policy_document.segment_emr_service_policy_document.json}"
-  tags   = "${local.tags}"
 }
 
 data "aws_iam_policy_document" "segment_emr_service_policy_document" {

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -126,7 +126,7 @@ data "aws_iam_policy_document" "segment_data_lake_policy_document" {
 
   # Explicitly deny Segment to modify IAM or sensible configuration from the Data Lake S3 bucket.
   statement {
-    sid     = "Deny privileged operations"
+    sid     = "DenyPrivilegedOperations"
     actions = [
       "s3:BypassGovernanceRetention",
       "s3:CreateAccessPoint",


### PR DESCRIPTION
I would like to discuss several parts of your proposed policies in order to stiffen the IAM control, as DataLake is one of the most valuable pieces of every single enterprise.

My proposal would be to discuss the commented lines of code, and also ask for your collaboration tagging all your created resources, so we can keep some of the IAM permissions, but constrained to a certain set of conditions (such as resource tagging) 