### PR TITLE
bugfix: remove tags field from iam policy as it is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform modules which create AWS resources for a Segment Data Lake.
 # Prerequisites
 
 * Authorized [AWS account](https://aws.amazon.com/account/).
-* Ability to run Terraform with your AWS Account. Terraform 0.11 and older are supported.
+* Ability to run Terraform with your AWS Account. Terraform 0.11+ (you can download tfswitch to help with switching your terraform version)
 * A subnet within a VPC for the EMR cluster to run in.
 * An [S3 Bucket](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket) for Segment to load data into. You can create a new one just for this, or re-use an existing one you already have.
 

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -44,7 +44,6 @@ resource "aws_iam_policy" "segment_data_lake_policy" {
   path        = "/"
   description = "Gives access to resources in your Data Lake"
   policy      = "${data.aws_iam_policy_document.segment_data_lake_policy_document.json}"
-  tags        = "${local.tags}"
 }
 
 data "aws_iam_policy_document" "segment_data_lake_policy_document" {


### PR DESCRIPTION
The AWS terraform module for IAM policy does not support the tags field, so it should be removed 