### PR TITLE
Ignore changes on EMR task instance_count

### DIFF
--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -120,6 +120,12 @@ resource "aws_emr_instance_group" "task" {
   instance_type  = "${var.task_instance_type}"
   instance_count = "${var.task_instance_count}"
 
+	lifecycle {
+    ignore_changes = [
+      instance_count # with autoscaling, the number of instances changes over time
+    ]
+  }
+
   ebs_config {
     size                 = "64"
     type                 = "gp2"


### PR DESCRIPTION
The `task_instance_count` value can change over time on the deployed EMR cluster because of autoscaling.

This prevents Terraform from changes the `task_instance_count` once the cluster is deployed.
