### PR TITLE
iam module changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ To simplify the set up process of not requiring an update to the IAM role for ea
 
 # Supported Terraform Versions
 
-Terraform 0.11 or higher is supported.
+Terraform 0.12 or higher is supported.
 
 In order to support more versions of Terraform, the AWS Provider needs to held at v2,
 as v3 has breaking changes we don't currently support. Our example `main.tf` has the

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -1,6 +1,7 @@
 ## Requirements
 
-No requirements.
+Works for version >= 0.12.
+Tags before 2021-08-20 work for version >=0.14
 
 ## Providers
 

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -1,6 +1,6 @@
 ## Requirements
 
-Works for version >= 0.11.
+Works for version >= 0.12
 
 ## Providers
 

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -1,7 +1,6 @@
 ## Requirements
 
-Works for version >= 0.12.
-Tags before 2021-08-20 work for version >=0.14
+Works for version >= 0.11.
 
 ## Providers
 

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -286,7 +286,7 @@ EOF
 
 resource "aws_iam_instance_profile" "segment_emr_instance_profile" {
   name  = "SegmentEMRInstanceProfile${var.suffix}"
-  roles = ["${aws_iam_role.segment_emr_instance_profile_role.name}"]
+  role = ["${aws_iam_role.segment_emr_instance_profile_role.name}"]
 }
 
 resource "aws_iam_role_policy" "segment_emr_instance_profile_policy" {

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -286,7 +286,7 @@ EOF
 
 resource "aws_iam_instance_profile" "segment_emr_instance_profile" {
   name = "SegmentEMRInstanceProfile${var.suffix}"
-  role = ["${aws_iam_role.segment_emr_instance_profile_role.name}"]
+  role = "${aws_iam_role.segment_emr_instance_profile_role.name}"
 }
 
 resource "aws_iam_role_policy" "segment_emr_instance_profile_policy" {

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -285,7 +285,7 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "segment_emr_instance_profile" {
-  name  = "SegmentEMRInstanceProfile${var.suffix}"
+  name = "SegmentEMRInstanceProfile${var.suffix}"
   role = ["${aws_iam_role.segment_emr_instance_profile_role.name}"]
 }
 


### PR DESCRIPTION
The 'roles' variable in the line 289 of iam.tf file gave an error for terraform versions below 0.14. It is changed to 'role'