### PR TITLE
docs: specify compatible versions for tflint

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ To develop in this repository, you'll want the following tools set up:
 
 * [Terraform](https://www.terraform.io/downloads.html), >= 0.12 (note that 0.12 is used to develop this module, even though 0.11 is supported)
 * [terraform-docs](https://github.com/segmentio/terraform-docs)
-* [tflint](https://github.com/terraform-linters/tflint)
+* [tflint](https://github.com/terraform-linters/tflint), 0.15.x - 0.26.x
 * [Ruby](https://www.ruby-lang.org/en/documentation/installation/), [>= 2.4.2](https://rvm.io)
 * [Bundler](https://bundler.io)
 


### PR DESCRIPTION
I discovered that the `tflint` usage in `Makefile` wasn't working with the latest version of `tflint`.  I figured out which versions have compatibility, and thought that info might be a good addition to the documentation.