### PR TITLE
add variables with defaults to AWS EMR module

### DIFF
--- a/aws_datalake/modules/emr/README.md
+++ b/aws_datalake/modules/emr/README.md
@@ -54,6 +54,30 @@ Type: `string`
 
 Default: `"segment-data-lake"`
 
+### emr\_cluster\_version
+
+Description: Version of emr cluster
+
+Type: `string`
+
+Default: `"6.5.0"`
+
+### additional\_applications
+
+Description: List of applications to install on the EMR cluster, besides Hadoop, Hive, and Spark.
+
+Type: `list(string)`
+
+Default: `[]`
+
+### key\_name
+
+Description: Amazon EC2 key pair that can be used to ssh to the master node as the user called hadoop.
+
+Type: `string`
+
+Default: `null`
+
 ### core\_instance\_count
 
 Description: Number of Core Nodes
@@ -102,9 +126,25 @@ Type: `string`
 
 Default: `""`
 
+### additional\_master\_security\_groups
+
+Description: String containing a comma separated list of additional Amazon EC2 security group IDs for the master node.
+
+Type: `string`
+
+Default: `""`
+
 ### slave\_security\_group
 
 Description: Identifier of the Amazon EC2 EMR-Managed security group for the slave nodes.
+
+Type: `string`
+
+Default: `""`
+
+### additional\_slave\_security\_groups
+
+Description: String containing a comma separated list of additional Amazon EC2 security group IDs for the slave nodes as a comma separated string.
 
 Type: `string`
 
@@ -141,6 +181,22 @@ Description: EC2 Instance Type for Task Nodes
 Type: `string`
 
 Default: `"m5.xlarge"`
+
+### ebs\_size
+
+Description: Volume size, in gibibytes (GiB)
+
+Type: `string`
+
+Default: `"64"`
+
+### ebs\_type
+
+Description: Volume type. Valid options are gp3, gp2, io1, standard, st1 and sc1.
+
+Type: `string`
+
+Default: `"gp2"`
 
 ## Outputs
 

--- a/aws_datalake/modules/emr/main.tf
+++ b/aws_datalake/modules/emr/main.tf
@@ -98,23 +98,7 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
 EOF
   }
 
-  configurations_json = <<EOF
-  [
-    {
-      "Classification": "hive-site",
-      "Properties": {
-        "hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
-      }
-    },
-    {
-      "Classification": "spark-hive-site",
-      "Properties": {
-        "hive.metastore.client.factory.class":"com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
-      }
-    }
-  ]
-EOF
-
+  configurations_json = var.configurations_json
   tags = local.tags
 }
 

--- a/aws_datalake/modules/emr/variables.tf
+++ b/aws_datalake/modules/emr/variables.tf
@@ -14,8 +14,20 @@ variable "master_security_group" {
   default     = ""
 }
 
+variable "additional_master_security_groups" {
+  description = "String containing a comma separated list of additional Amazon EC2 security group IDs for the master node."
+  type        = string
+  default     = ""
+}
+
 variable "slave_security_group" {
   description = "Identifier of the Amazon EC2 EMR-Managed security group for the slave nodes."
+  type        = string
+  default     = ""
+}
+
+variable "additional_slave_security_groups" {
+  description = "String containing a comma separated list of additional Amazon EC2 security group IDs for the slave nodes as a comma separated string."
   type        = string
   default     = ""
 }
@@ -52,6 +64,19 @@ variable "iam_emr_instance_profile" {
   description = "Name of the EMR EC2 instance profile"
   type        = string
 }
+
+variable "key_name" {
+  description = "Amazon EC2 key pair that can be used to ssh to the master node as the user called hadoop."
+  type        = string
+  default     = null
+}
+
+# FIXME requires aws provider v5
+#variable "unhealthy_node_replacement" {
+#  description = "Whether Amazon EMR should gracefully replace core nodes that have degraded within the cluster."
+#  type        = bool
+#  default     = false
+#}
 
 variable "master_instance_type" {
   description = "EC2 Instance Type for Master"
@@ -99,6 +124,24 @@ variable "emr_cluster_version" {
   description = "Version of emr cluster"
   type        = string
   default     = "6.5.0"
+}
+
+variable "additional_applications" {
+  description = "List of applications to install on the EMR cluster, besides Hadoop, Hive, and Spark."
+  type        = list(string)
+  default     = []
+}
+
+variable "ebs_size" {
+  description = "Volume size, in gibibytes (GiB)"
+  type        = string
+  default     = "64"
+}
+
+variable "ebs_type" {
+  description = "Volume type. Valid options are gp3, gp2, io1, standard, st1 and sc1."
+  type        = string
+  default     = "gp2"
 }
 
 locals {

--- a/aws_datalake/modules/emr/variables.tf
+++ b/aws_datalake/modules/emr/variables.tf
@@ -144,6 +144,35 @@ variable "ebs_type" {
   default     = "gp2"
 }
 
+variable "configurations_json" {
+  description = "JSON string for supplying list of configurations for the EMR cluster."
+  type        = string
+  default     = <<-EOF
+    [
+      {
+        "Classification": "hive-site",
+        "Properties": {
+          "hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+        }
+      },
+      {
+        "Classification": "spark-hive-site",
+        "Properties": {
+          "hive.metastore.client.factory.class":"com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+        }
+      },
+      {
+        "Classification": "spark-defaults",
+        "Properties": {
+          "spark.history.fs.cleaner.enabled": "true",
+          "spark.history.fs.cleaner.interval": "1d",
+          "spark.history.fs.cleaner.maxAge": "7d"
+        }
+      }
+    ]
+  EOF
+}
+
 locals {
   tags = merge(tomap({"vendor" = "segment"}), var.tags)
 }


### PR DESCRIPTION
This allows for some additional configuration, but defaults to the current hard-coded or empty values. The important one for us is the `key_name` so that we can do some troubleshooting.

Adding `unhealthy_node_replacement` would be a breaking change for v4 that the example uses, so I just commented that out until it's been updated.