### PR TITLE
Migrate to Twilio buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,12 @@
-steps:
-  - label: ":lint-roller: fmtcheck"
-    plugins:
-      - docker#v3.3.0:
-          image: hashicorp/terraform:0.12.31
-          command: ["fmt", "-recursive"]
+agents:
+  queue: general-039
 
-  - label: ":lint-roller: Lint"
+env:
+  ECR_REGISTRY: 018537234677.dkr.ecr.us-east-1.amazonaws.com
+
+steps:
+  - label: ":lint-roller: Linted"
     plugins:
-      - docker#v3.3.0:
-          image: wata727/tflint:0.12.1
-          commands: make lint
+      - docker#v5.12.0:
+          image: ${ECR_REGISTRY}/docker.io/hashicorp/terraform:1.15.5
+          command: ["fmt", "-check", "-recursive", "-diff"]

--- a/aws_datalake/modules/emr/variables.tf
+++ b/aws_datalake/modules/emr/variables.tf
@@ -102,5 +102,5 @@ variable "emr_cluster_version" {
 }
 
 locals {
-  tags = merge(tomap({"vendor" = "segment"}), var.tags)
+  tags = merge(tomap({ "vendor" = "segment" }), var.tags)
 }

--- a/aws_datalake/modules/iam/variables.tf
+++ b/aws_datalake/modules/iam/variables.tf
@@ -36,5 +36,5 @@ variable "tags" {
 }
 
 locals {
-  tags = merge(tomap({"vendor" = "segment"}), var.tags)
+  tags = merge(tomap({ "vendor" = "segment" }), var.tags)
 }

--- a/aws_datalake/test/test_fixture/aws_main.tf
+++ b/aws_datalake/test/test_fixture/aws_main.tf
@@ -27,10 +27,10 @@ module "iam" {
 module "emr" {
   source = "../../modules/emr"
 
-  s3_bucket    = "data_lake_tf_test_s3_bucket"
-  subnet_id    = "subnet-00f137e4f3a6f8356"
-  tags         = local.tags
-  cluster_name = "test-cluster"
+  s3_bucket           = "data_lake_tf_test_s3_bucket"
+  subnet_id           = "subnet-00f137e4f3a6f8356"
+  tags                = local.tags
+  cluster_name        = "test-cluster"
   emr_cluster_version = "7.0.0"
 
   # LEAVE THIS AS-IS

--- a/azure_datalake/modules/StorageAccount/main.tf
+++ b/azure_datalake/modules/StorageAccount/main.tf
@@ -1,6 +1,6 @@
 resource "azurerm_storage_container" "segment_data_lake_storage_container" {
-  name                  = var.container_name
-  storage_account_name  = azurerm_storage_account.segment_data_lake_storage_account.name
+  name                 = var.container_name
+  storage_account_name = azurerm_storage_account.segment_data_lake_storage_account.name
 }
 
 resource "azurerm_storage_account" "segment_data_lake_storage_account" {

--- a/azure_datalake/modules/StorageAccount/output.tf
+++ b/azure_datalake/modules/StorageAccount/output.tf
@@ -1,11 +1,11 @@
 output "storage_account_name" {
-  value       = azurerm_storage_account.segment_data_lake_storage_account.name
+  value = azurerm_storage_account.segment_data_lake_storage_account.name
 }
 
 output "storage_container_name" {
-  value       = azurerm_storage_container.segment_data_lake_storage_container.name
+  value = azurerm_storage_container.segment_data_lake_storage_container.name
 }
 
 output "region" {
-  value       = azurerm_storage_account.segment_data_lake_storage_account.location
+  value = azurerm_storage_account.segment_data_lake_storage_account.location
 }

--- a/azure_datalake/modules/databricks/main.tf
+++ b/azure_datalake/modules/databricks/main.tf
@@ -9,9 +9,9 @@ provider "databricks" {
 }
 
 resource "databricks_cluster" "segment_databricks_cluster" {
-  cluster_name            = var.cluster_name
-  spark_version           = "9.1.x-scala2.12"
-  node_type_id            = "Standard_DS4_v2"
+  cluster_name  = var.cluster_name
+  spark_version = "9.1.x-scala2.12"
+  node_type_id  = "Standard_DS4_v2"
 
   autoscale {
     min_workers = 2
@@ -20,29 +20,29 @@ resource "databricks_cluster" "segment_databricks_cluster" {
 
   spark_conf = {
 
-    "spark.hive.mapred.supports.subdirectories": true,
-    "spark.sql.storeAssignmentPolicy": "Legacy",
-    "mapreduce.input.fileinputformat.input.dir.recursive": true,
-    "spark.sql.hive.convertMetastoreParquet": false,
+    "spark.hive.mapred.supports.subdirectories" : true,
+    "spark.sql.storeAssignmentPolicy" : "Legacy",
+    "mapreduce.input.fileinputformat.input.dir.recursive" : true,
+    "spark.sql.hive.convertMetastoreParquet" : false,
 
-    "datanucleus.autoCreateSchema": true,
-    "datanucleus.autoCreateTables": true,
-    "spark.sql.hive.metastore.schema.verification": false,
-    "datanucleus.fixedDatastore": false,
+    "datanucleus.autoCreateSchema" : true,
+    "datanucleus.autoCreateTables" : true,
+    "spark.sql.hive.metastore.schema.verification" : false,
+    "datanucleus.fixedDatastore" : false,
 
-    "spark.sql.hive.metastore.version": "2.3.7",
-    "spark.sql.hive.metastore.jars": "builtin",
+    "spark.sql.hive.metastore.version" : "2.3.7",
+    "spark.sql.hive.metastore.jars" : "builtin",
 
-    "spark.hadoop.fs.azure.account.oauth.provider.type.${var.storage_account_name}.dfs.core.windows.net": "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider",
-    "spark.hadoop.fs.azure.account.oauth2.client.endpoint.${var.storage_account_name}.dfs.core.windows.net": "https://login.microsoftonline.com/${var.tenant_id}/oauth2/token",
-    "spark.hadoop.fs.azure.account.oauth2.client.secret.${var.storage_account_name}.dfs.core.windows.net": var.service_principal_secret,
-    "spark.hadoop.fs.azure.account.auth.type.${var.storage_account_name}.dfs.core.windows.net": "OAuth",
-    "spark.hadoop.fs.azure.account.oauth2.client.id.${var.storage_account_name}.dfs.core.windows.net": var.service_principal_id,
+    "spark.hadoop.fs.azure.account.oauth.provider.type.${var.storage_account_name}.dfs.core.windows.net" : "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider",
+    "spark.hadoop.fs.azure.account.oauth2.client.endpoint.${var.storage_account_name}.dfs.core.windows.net" : "https://login.microsoftonline.com/${var.tenant_id}/oauth2/token",
+    "spark.hadoop.fs.azure.account.oauth2.client.secret.${var.storage_account_name}.dfs.core.windows.net" : var.service_principal_secret,
+    "spark.hadoop.fs.azure.account.auth.type.${var.storage_account_name}.dfs.core.windows.net" : "OAuth",
+    "spark.hadoop.fs.azure.account.oauth2.client.id.${var.storage_account_name}.dfs.core.windows.net" : var.service_principal_id,
 
-    "spark.hadoop.javax.jdo.option.ConnectionDriverName": "org.mariadb.jdbc.Driver",
-    "spark.hadoop.javax.jdo.option.ConnectionURL": "jdbc:mysql://${var.mysql_server_url}:3306/${var.mysql_dbname}?useSSL=true&requireSSL=true&enabledSslProtocolSuites=TLSv1.2",
-    "spark.hadoop.javax.jdo.option.ConnectionUserName": var.mysql_username,
-    "spark.hadoop.javax.jdo.option.ConnectionPassword": var.mysql_password
+    "spark.hadoop.javax.jdo.option.ConnectionDriverName" : "org.mariadb.jdbc.Driver",
+    "spark.hadoop.javax.jdo.option.ConnectionURL" : "jdbc:mysql://${var.mysql_server_url}:3306/${var.mysql_dbname}?useSSL=true&requireSSL=true&enabledSslProtocolSuites=TLSv1.2",
+    "spark.hadoop.javax.jdo.option.ConnectionUserName" : var.mysql_username,
+    "spark.hadoop.javax.jdo.option.ConnectionPassword" : var.mysql_password
   }
 }
 
@@ -52,8 +52,8 @@ resource "databricks_group" "segment" {
 }
 
 resource "databricks_user" "me" {
-  user_name = "datalakes@segment.com"
-  external_id = var.service_principal_id
+  user_name    = "datalakes@segment.com"
+  external_id  = var.service_principal_id
   display_name = "segment"
 }
 

--- a/azure_datalake/modules/databricks/output.tf
+++ b/azure_datalake/modules/databricks/output.tf
@@ -1,3 +1,3 @@
 output "databricks_cluster_id" {
-  value  = databricks_cluster.segment_databricks_cluster.id
+  value = databricks_cluster.segment_databricks_cluster.id
 }

--- a/azure_datalake/modules/mysql/main.tf
+++ b/azure_datalake/modules/mysql/main.tf
@@ -16,9 +16,9 @@ resource "azurerm_mysql_server" "segment_mysql_server" {
   administrator_login          = var.db_admin
   administrator_login_password = var.password
 
-  sku_name   = "B_Gen5_1"  //tier+family+core
-  version    = "5.7"
-  storage_mb = 5120
-  ssl_enforcement_enabled  = true
+  sku_name                = "B_Gen5_1" //tier+family+core
+  version                 = "5.7"
+  storage_mb              = 5120
+  ssl_enforcement_enabled = true
 }
 

--- a/azure_datalake/modules/serviceprincipal/main.tf
+++ b/azure_datalake/modules/serviceprincipal/main.tf
@@ -13,9 +13,9 @@ resource "azuread_service_principal_password" "segment_sp_password" {
 }
 
 resource "azuread_service_principal" "segment_service_principal" {
-  application_id  = azuread_application.segment_service_application.application_id
+  application_id = azuread_application.segment_service_application.application_id
 }
 
 resource "azuread_application" "segment_service_application" {
-  display_name     = var.app_name
+  display_name = var.app_name
 }

--- a/azure_datalake/test/test_fixture/azure_main.tf
+++ b/azure_datalake/test/test_fixture/azure_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     databricks = {
-      source  = "databrickslabs/databricks"
+      source = "databrickslabs/databricks"
     }
 
     azurerm = "~> 2"
@@ -29,14 +29,14 @@ locals {
   db_password = ""
   db_admin    = ""
 
-  start_ip          = "0.0.0.0"
-  end_ip            = "255.255.255.255"
-  sku               = "premium"
+  start_ip               = "0.0.0.0"
+  end_ip                 = "255.255.255.255"
+  sku                    = "premium"
   service_principal_name = ""
 
   databricks_workspace_url = ""
-  cluster_name   = ""
-  tenant_id      = ""
+  cluster_name             = ""
+  tenant_id                = ""
 }
 
 resource "azurerm_resource_group" "segment_datalake" {
@@ -65,22 +65,22 @@ resource "azurerm_key_vault_access_policy" "segment_vault" {
 module "segment_data_lake_storage_account" {
   source = "./modules/storageaccount"
 
-  name           = local.storage_account
-  region         = local.region
+  name                = local.storage_account
+  region              = local.region
   resource_group_name = azurerm_resource_group.segment_datalake.name
-  container_name = local.container_name
+  container_name      = local.container_name
 }
 
 module "segment_data_lake_mysql" {
   source = "./modules/mysql"
 
 
-  region = local.region
-  server_name = local.server_name
+  region              = local.region
+  server_name         = local.server_name
   resource_group_name = azurerm_resource_group.segment_datalake.name
-  db_name     = local.db_name
-  db_admin    = local.db_admin
-  password   =  local.db_password
+  db_name             = local.db_name
+  db_admin            = local.db_admin
+  password            = local.db_password
 
 }
 
@@ -92,7 +92,7 @@ module "segment_data_lake_service_principal" {
 }
 
 module "segment_data_lake_databricks_cluster" {
-  source = "./modules/databricks"
+  source        = "./modules/databricks"
   workspace_url = local.databricks_workspace_url
 
   cluster_name             = local.cluster_name


### PR DESCRIPTION
## Summary

Migrates the Buildkite pipeline from Segment Buildkite to Twilio Buildkite.

### Pipeline changes (`.buildkite/pipeline.yml`)
- Pins the pipeline to the Twilio Buildkite agent queue `general-039`.
- Pulls the Terraform image through the Twilio internal ECR proxy (`018537234677.dkr.ecr.us-east-1.amazonaws.com`) instead of pulling `hashicorp/terraform` directly from Docker Hub.
- Bumps the `docker` plugin `v3.3.0` → `v5.12.0` and the Terraform image to `1.15.5`.
- Consolidates the previous `fmtcheck` + `Lint` steps into a single `fmt -check -recursive -diff` step.

### Formatting
- Ran `terraform fmt` across the `aws_datalake` and `azure_datalake` modules and test fixtures so the new `fmt -check` step passes. These changes are whitespace/alignment only — no functional Terraform changes.
